### PR TITLE
comma-separated string values for block-types and colored dropmenu items

### DIFF
--- a/matrixcolors/MatrixColorsPlugin.php
+++ b/matrixcolors/MatrixColorsPlugin.php
@@ -101,12 +101,24 @@ class MatrixColorsPlugin extends BasePlugin
 		$css = '';
 		if ($this->_matrixBlockColors) {
 			foreach ($this->_matrixBlockColors as $row) {
-				$type = $row['blockType'];
+				//	in case of comma-separated string is given extract all block type handles
+				$types = explode(',', $row['blockType']);
 				$color = $row['backgroundColor'];
-				$colorList[] = $type;
-				$css .= "
+
+				//	iterate each handle for the current color definition
+				foreach ($types as $type) {
+					$type = trim($type);
+
+					//	ensure we only accept non-empty strings
+					if (empty($type)) {
+						continue;
+					}
+
+					$colorList[] = $type;
+					$css .= "
 .mc-solid-{$type} {background-color: {$color};}
 .btngroup .btn.mc-gradient-{$type} {background-image: linear-gradient(white,{$color});}";
+				}
 			}
 			craft()->templates->includeCss($css);
 		}

--- a/matrixcolors/resources/js/matrixcolors.js
+++ b/matrixcolors/resources/js/matrixcolors.js
@@ -18,10 +18,18 @@ function colorizeMatrixButtons() {
 	}
 }
 
+// Find list items in dropdown menu related to Matrix, update background color
+function colorizeMatrixDropdown() {
+	for (var i in colorList) {
+		$('.menu').find('a[data-type="'+colorList[i]+'"]').addClass('mc-solid-'+colorList[i]);
+	}
+}
+
 // Colorize all components
 function colorizeAll() {
 	colorizeMatrixBlocks();
 	colorizeMatrixButtons();
+	colorizeMatrixDropdown();
 }
 
 // Refresh colorization over a timed period
@@ -47,6 +55,7 @@ $(function () {
 // Listen for new blocks
 $(document).on('click', '.matrix .btn, .menu ul li a', function () {
 	colorizeMatrixBlocks();
+	colorizeMatrixDropdown();
 });
 
 // Listen for changed entry type


### PR DESCRIPTION
Just forget the recently added issue by me:
#7 "Feature request: Allow comma-seperated handles"

I couldn't wait for it and I couldn't resist to just resolve this thing on my own. Hope, you're fine with it.