### PR TITLE
Adds Neo support

### DIFF
--- a/src/MatrixColors.php
+++ b/src/MatrixColors.php
@@ -141,6 +141,7 @@ class MatrixColors extends Plugin
 .mc-solid-{$type} {background-color: {$color};}
 .btngroup .btn.mc-gradient-{$type} {background-image: linear-gradient(white,{$color});}";
                     // If Neo is installed and enabled, set CSS for even-level blocks and Matrix sub-fields
+                    // (since Neo sets styles for those cases which will override the above)
                     if ($addNeoCss) {
                         $css .= "
 .ni_block.is-level-even.mc-solid-{$type}, .ni_block .matrix .mc-solid-{$type} {background-color: {$color};}

--- a/src/MatrixColors.php
+++ b/src/MatrixColors.php
@@ -114,8 +114,10 @@ class MatrixColors extends Plugin
     private function _colorBlocks(): void
     {
         $view = Craft::$app->getView();
+        $pluginsService = Craft::$app->getPlugins();
         $settings = $this->getSettings();
         $this->_matrixBlockColors = $settings->matrixBlockColors ?? [];
+        $addNeoCss = $pluginsService->isPluginInstalled('neo') && $pluginsService->isPluginEnabled('neo');
         $css = '';
         $colorList = [];
         // Loop through block colors
@@ -138,6 +140,12 @@ class MatrixColors extends Plugin
                     $css .= "
 .mc-solid-{$type} {background-color: {$color};}
 .btngroup .btn.mc-gradient-{$type} {background-image: linear-gradient(white,{$color});}";
+                    // If Neo is installed and enabled, set CSS for even-level blocks
+                    if ($addNeoCss) {
+                        $css .= "
+.ni_block.is-level-even.mc-solid-{$type} {background-color: {$color};}
+.ni_block.is-level-even.mc-solid-{$type} > .ni_block_body {background-color: rgba(255, 255, 255, 0.5);}";
+                    }
                 }
             }
             // Load CSS

--- a/src/MatrixColors.php
+++ b/src/MatrixColors.php
@@ -140,10 +140,10 @@ class MatrixColors extends Plugin
                     $css .= "
 .mc-solid-{$type} {background-color: {$color};}
 .btngroup .btn.mc-gradient-{$type} {background-image: linear-gradient(white,{$color});}";
-                    // If Neo is installed and enabled, set CSS for even-level blocks
+                    // If Neo is installed and enabled, set CSS for even-level blocks and Matrix sub-fields
                     if ($addNeoCss) {
                         $css .= "
-.ni_block.is-level-even.mc-solid-{$type} {background-color: {$color};}
+.ni_block.is-level-even.mc-solid-{$type}, .ni_block .matrix .mc-solid-{$type} {background-color: {$color};}
 .ni_block.is-level-even.mc-solid-{$type} > .ni_block_body {background-color: rgba(255, 255, 255, 0.5);}";
                     }
                 }

--- a/src/resources/js/matrixcolors.js
+++ b/src/resources/js/matrixcolors.js
@@ -28,11 +28,27 @@ function colorizeMatrixMenus() {
     }
 }
 
+// Find buttons related to Neo, update background color
+function colorizeNeoButtons() {
+    for (var i in colorList) {
+        $('.neo-input').find('.btn[data-neo-bn-info="'+colorList[i]+'"]').addClass('mc-gradient-'+colorList[i]);
+    }
+}
+
+// Find list items in menus related to Neo, update background color
+function colorizeNeoMenus() {
+    for (var i in colorList) {
+        $('.menu').find('a[data-neo-bn-info="'+colorList[i]+'"]').addClass('mc-solid-'+colorList[i]);
+    }
+}
+
 // Colorize all components
 function colorizeAll() {
     colorizeMatrixBlocks();
     colorizeMatrixButtons();
     colorizeMatrixMenus();
+    colorizeNeoButtons();
+    colorizeNeoMenus();
 }
 
 // Refresh colorization over a timed period
@@ -53,18 +69,30 @@ function timedRefresh() {
 // On load, colorize blocks
 $(function () {
     colorizeAll();
-    // Colorize existing menus
+    // Colorize existing menus and Neo buttons
     var observer = new MutationObserver(function() {
         colorizeMatrixMenus();
+        colorizeNeoButtons();
+        colorizeNeoMenus();
     });
     observer.observe(document.body, {childList: true});
 });
 
-// Listen for new blocks
+// Listen for new Matrix blocks
 $(document).on('click', '.matrix .btn, .menu ul li a', function () {
     colorizeMatrixBlocks();
     colorizeMatrixMenus();
 });
+
+// Listen for new Neo blocks
+$(document).on(
+    'click',
+    '.neo-input .btn, a[data-neo-bn="button.addBlock"], .menu ul li a[data-action="add"]',
+    function () {
+        colorizeNeoButtons();
+        colorizeNeoMenus();
+    }
+);
 
 // Listen for changed entry type
 $(document).on('change', '#entryType', function () {

--- a/src/resources/js/matrixcolors.js
+++ b/src/resources/js/matrixcolors.js
@@ -1,17 +1,21 @@
 // ==================================================================== //
 // BEHAVIOR
 
-// Find all matrix blocks, add specified background color
-function colorizeMatrixBlocks() {
+function _colorizeBlocks(blockClass, blockTitlebarClass) {
     var blockType;
-    $('.matrixblock').each(function () {
+    $(blockClass).each(function () {
         blockType = $(this).find('input[type="hidden"][name*="][type]"]').val();
         // If block type is in the color list
         if (-1 < colorList.indexOf(blockType)) {
             $(this).addClass('mc-solid-'+blockType);
-            $(this).find('.titlebar').css({'background-color':'rgba(255, 255, 255, 0.5)'});
+            $(this).find(blockTitlebarClass).css({'background-color':'rgba(255, 255, 255, 0.5)'});
         }
     });
+}
+
+// Find all matrix blocks, add specified background color
+function colorizeMatrixBlocks() {
+    _colorizeBlocks('.matrixblock', '.titlebar');
 }
 
 // Find buttons related to Matrix, update background color
@@ -26,6 +30,11 @@ function colorizeMatrixMenus() {
     for (var i in colorList) {
         $('.menu').find('a[data-type="'+colorList[i]+'"]').addClass('mc-solid-'+colorList[i]);
     }
+}
+
+// Find all Neo blocks, add specified background color
+function colorizeNeoBlocks() {
+    _colorizeBlocks('.ni_block', '.ni_block_topbar');
 }
 
 // Find buttons related to Neo, update background color
@@ -47,6 +56,7 @@ function colorizeAll() {
     colorizeMatrixBlocks();
     colorizeMatrixButtons();
     colorizeMatrixMenus();
+    colorizeNeoBlocks();
     colorizeNeoButtons();
     colorizeNeoMenus();
 }
@@ -89,6 +99,7 @@ $(document).on(
     'click',
     '.neo-input .btn, a[data-neo-bn="button.addBlock"], .menu ul li a[data-action="add"]',
     function () {
+        colorizeNeoBlocks();
         colorizeNeoButtons();
         colorizeNeoMenus();
     }


### PR DESCRIPTION
Adds Neo support, by applying the colours in the plugin's existing settings table for Matrix block types to the Neo blocks/buttons/menu options associated with Neo block types with the specified handles. Resolves #13.

To aid in visibility of nested Neo blocks, even-level Neo blocks have the lighter look of title bars applied to the entire block, e.g. the following screenshot:

<img width="764" alt="Screen Shot 2022-08-28 at 20 38 10" src="https://user-images.githubusercontent.com/19421878/187070607-d1eea90b-c04f-47ff-89c8-d5b96314eca9.png">

Happy to make any necessary changes related to the look or code, please let me know.